### PR TITLE
Fixing output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,6 @@ output "policy_rule" {
   description = "ECR Policy Rule"
 
   value = "${replace(
-           replace(
 		 replace(element(concat(
              data.template_file.lifecycle_policy_imageCountMoreThan_tagged.*.rendered,
              data.template_file.lifecycle_policy_imageCountMoreThan_untagged_or_any.*.rendered,
@@ -14,6 +13,5 @@ output "policy_rule" {
 			      ),0),
 			 "/\"(true|false|[[:digit:]]+)\"/", "$1"
 		), "string:", ""
-	      ), "priority:replace:this", "${join("",list("$$$","{rule_priority}"))}"
-            )}"
+	      )}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,7 @@ variable "create" {
 }
 
 variable "rule_priority" {
-  description = "The Priority of the rule, when not given the default priority:replace:this it will be replaced by $${rule_priority} for later template_file interpretation"
+  description = "The Priority of the rule, when not given the default priority:replace:this is set for later interpretation/replacement"
   default     = "priority:replace:this"
 }
 


### PR DESCRIPTION
$${rule_priority} does not seem to get rendered when used later inside a template file. Rule priority will now be set to priority:replace:this which can be replaced at a later moment.